### PR TITLE
Remove roles from database section in manifest

### DIFF
--- a/snowflake-manifest-from-share-library/snowflake_manifest_from_share/share_manifest_generator.py
+++ b/snowflake-manifest-from-share-library/snowflake_manifest_from_share/share_manifest_generator.py
@@ -322,7 +322,6 @@ class ShareManifestGenerator:
         database_list = []
         for db_name, db_content in databases.items():
             schema_list = []
-            db_roles = list(role_mappings['databases'].get(db_name, set()))
             
             for schema_name, schema_content in db_content['schemas'].items():
                 schema_key = f"{db_name}.{schema_name}"
@@ -360,13 +359,7 @@ class ShareManifestGenerator:
                 
                 schema_list.append(schema_dict)
             
-            db_dict = {db_name: {}}
-            
-            # Add database roles if there are any
-            if db_roles:
-                db_dict[db_name]['roles'] = FlowStyleList(db_roles)
-                
-            db_dict[db_name]['schemas'] = schema_list
+            db_dict = {db_name: {'schemas': schema_list}}
             database_list.append(db_dict)
         
         return {'databases': database_list}, role_mappings

--- a/snowflake-manifest-from-share-library/tests/test_share_manifest_generator.py
+++ b/snowflake-manifest-from-share-library/tests/test_share_manifest_generator.py
@@ -111,9 +111,11 @@ class TestShareManifestGenerator:
         assert 'TEST_ROLE' in result['roles'][0]
         assert result['roles'][0]['TEST_ROLE']['comment'] == 'Test role comment'
 
-        # Verify database has role
+        # Verify database structure (databases should not have roles)
         databases = result['shared_content']['databases']
-        assert 'TEST_ROLE' in databases[0]['TEST_DB']['roles'].items
+        assert 'TEST_DB' in databases[0]
+        assert 'roles' not in databases[0]['TEST_DB']
+        assert 'schemas' in databases[0]['TEST_DB']
 
     def test_analyze_share_with_views(self, generator, mock_connection):
         """Test manifest generation with views."""
@@ -301,9 +303,10 @@ class TestShareManifestGenerator:
         assert 'DR1' in result['roles'][0]
         assert result['roles'][0]['DR1']['comment'] == 'Demo role'
 
-        # Verify database has DR1 role
+        # Verify database structure (databases should not have roles)
         db = result['shared_content']['databases'][0]['DEMO_DB']
-        assert 'DR1' in db['roles'].items
+        assert 'roles' not in db
+        assert 'schemas' in db
 
         # Verify schema has DR1 role  
         schema = db['schemas'][0]['ANALYTICS']


### PR DESCRIPTION
- Database section in YAML manifest does not support roles
- Removed code that adds roles to database objects
- Updated tests to verify databases do not have roles field
- Schemas, tables, and views continue to support roles