### PR TITLE
Improve YAML formatting to add proper indentation for list items

### DIFF
--- a/snowflake-manifest-from-share-library/snowflake_manifest_from_share/yaml_formatter.py
+++ b/snowflake-manifest-from-share-library/snowflake_manifest_from_share/yaml_formatter.py
@@ -17,7 +17,10 @@ class FlowStyleList:
 
 class CustomYAMLDumper(yaml.SafeDumper):
     """Custom YAML dumper with thread-safe representers."""
-    pass
+    
+    def increase_indent(self, flow=False, indentless=False):
+        """Override to add proper indentation for list items."""
+        return super(CustomYAMLDumper, self).increase_indent(flow, False)
 
 def represent_empty_value(dumper, data):
     """Custom YAML representer for empty values."""


### PR DESCRIPTION
- Override increase_indent method in CustomYAMLDumper to prevent indentless lists
- List items now have proper 2-space indentation before the dash